### PR TITLE
Update Dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,7 +34,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.facebook.android:facebook-core:[5,6)'
-        implementation 'com.facebook.android:facebook-applinks:[5,6)'
+        implementation 'com.facebook.android:facebook-core:12.2.0'
+        implementation 'com.facebook.android:facebook-applinks:12.2.0'
     }
 }

--- a/ios/flutter_facebook_app_links.podspec
+++ b/ios/flutter_facebook_app_links.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_facebook_app_links'
-  s.version          = '0.0.3'
+  s.version          = '0.0.4'
   s.summary          = 'A Flutter plugin to catch deferred deep links from Facebbok ads with FB App Links SDK.'
   s.description      = <<-DESC
 Flutter plugin for Facebook App Links SDK
@@ -15,7 +15,7 @@ Flutter plugin for Facebook App Links SDK
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FBSDKCoreKit', '~> 9.1.0'
+  s.dependency 'FBSDKCoreKit', '~> 12.2.1'
   s.swift_version       = '4.0'
 
   s.ios.deployment_target = '8.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_facebook_app_links
 description: A Flutter plugin to catch deferred deep links from Facebbok ads with FB App Links SDK.
-version: 2.0.0+2
+version: 2.0.0+3
 homepage: https://github.com/Mapk26/flutter_facebook_app_links
 
 environment:


### PR DESCRIPTION
Because the current version is using FBSDKCoreKit version 9.1.0, and other facebook related library already using SDK version 12, this library should update the dependency to 12 as well. Also cocoapods can't deal with multiple version of the same dependency.
