### PR TITLE
[FIX] error: 'nil' is not compatible with expected argument type 'ApplicationDelegate'

### DIFF
--- a/ios/Classes/SwiftFlutterFacebookAppLinksPlugin.swift
+++ b/ios/Classes/SwiftFlutterFacebookAppLinksPlugin.swift
@@ -75,7 +75,7 @@ public class SwiftFlutterFacebookAppLinksPlugin: NSObject, FlutterPlugin {
   }
 
   public func initializeSDK() {
-      ApplicationDelegate.initializeSDK(nil)
+      ApplicationDelegate.shared.initializeSDK()
   }
 
   


### PR DESCRIPTION
This error occured to me, and need to change the function call.

Ref: https://github.com/facebook/facebook-ios-sdk/issues/1731#issuecomment-987808555