### PR TITLE
Fixed build for Flutter 3.29

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/android/src/main/java/it/remedia/flutter_facebook_app_links/FlutterFacebookAppLinksPlugin.java
+++ b/android/src/main/java/it/remedia/flutter_facebook_app_links/FlutterFacebookAppLinksPlugin.java
@@ -26,7 +26,6 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;
 import io.flutter.plugin.common.PluginRegistry;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FlutterFacebookAppLinksPlugin */
 public class FlutterFacebookAppLinksPlugin implements FlutterPlugin, MethodCallHandler {


### PR DESCRIPTION
Fixed the build for Flutter 3.29 by removing an old deprecated tool that was however not being used anymore.